### PR TITLE
fix: remove unused decimal encoding extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/swift,xcode
+
+## vs code
+.vscode

--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -27,3 +27,4 @@
 git_push.sh
 BasisTheory.podspec
 README.md
+BasisTheory/Extensions.swift

--- a/BasisTheory/Extensions.swift
+++ b/BasisTheory/Extensions.swift
@@ -144,18 +144,6 @@ extension KeyedEncodingContainerProtocol {
             try encodeMap(pairs)
         }
     }
-
-    public mutating func encode(_ value: Decimal, forKey key: Self.Key) throws {
-        var mutableValue = value
-        let stringValue = NSDecimalString(&mutableValue, Locale(identifier: "en_US"))
-        try encode(stringValue, forKey: key)
-    }
-
-    public mutating func encodeIfPresent(_ value: Decimal?, forKey key: Self.Key) throws {
-        if let value = value {
-            try encode(value, forKey: key)
-        }
-    }
 }
 
 extension KeyedDecodingContainerProtocol {
@@ -194,29 +182,6 @@ extension KeyedDecodingContainerProtocol {
 
         return map
     }
-
-    public func decode(_ type: Decimal.Type, forKey key: Self.Key) throws -> Decimal {
-        let stringValue = try decode(String.self, forKey: key)
-        guard let decimalValue = Decimal(string: stringValue) else {
-            let context = DecodingError.Context(codingPath: [key], debugDescription: "The key \(key) couldn't be converted to a Decimal value")
-            throw DecodingError.typeMismatch(type, context)
-        }
-
-        return decimalValue
-    }
-
-    public func decodeIfPresent(_ type: Decimal.Type, forKey key: Self.Key) throws -> Decimal? {
-        guard let stringValue = try decodeIfPresent(String.self, forKey: key) else {
-            return nil
-        }
-        guard let decimalValue = Decimal(string: stringValue) else {
-            let context = DecodingError.Context(codingPath: [key], debugDescription: "The key \(key) couldn't be converted to a Decimal value")
-            throw DecodingError.typeMismatch(type, context)
-        }
-
-        return decimalValue
-    }
-
 }
 
 extension HTTPURLResponse {


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Removes overridden `encode` and `decode` methods for `Decimal` values
  - This was added by the open-api generator but is not necessary for the BasisTheory APIs

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
